### PR TITLE
[#14] Add missing match_phrase query

### DIFF
--- a/lib/elasticsearch/dsl/search/queries/match.rb
+++ b/lib/elasticsearch/dsl/search/queries/match.rb
@@ -40,19 +40,21 @@ module Elasticsearch
           include BaseComponent
 
           option_method :query
+          option_method :analyzer
+          option_method :auto_generate_synonyms_phrase_query
+          option_method :fuzziness
+          option_method :max_expansions
+          option_method :prefix_length
+          option_method :fuzzy_transpositions
+          option_method :fuzzy_rewrite
+          option_method :lenient
           option_method :operator
           option_method :minimum_should_match
+          option_method :zero_terms_query
+
           option_method :type
           option_method :boost
-          option_method :fuzziness
-          option_method :prefix_length
-          option_method :max_expansions
-          option_method :fuzzy_rewrite
-          option_method :analyzer
-          option_method :lenient
-          option_method :zero_terms_query
           option_method :cutoff_frequency
-          option_method :max_expansions
         end
 
       end

--- a/spec/elasticsearch/dsl/search/queries/match_spec.rb
+++ b/spec/elasticsearch/dsl/search/queries/match_spec.rb
@@ -68,6 +68,22 @@ describe Elasticsearch::DSL::Search::Queries::Match do
         expect(search.to_hash[:match][:type]).to eq(10)
       end
     end
+
+    describe '#auto_generate_synonyms_phrase_query' do
+      it 'applies the option' do
+        search.auto_generate_synonyms_phrase_query 'false'
+
+        expect(search.to_hash[:match][:auto_generate_synonyms_phrase_query]).to eq('false')
+      end
+    end
+
+    describe '#fuzzy_transpositions' do
+      it 'applies the option' do
+        search.fuzzy_transpositions 'false'
+
+        expect(search.to_hash[:match][:fuzzy_transpositions]).to eq('false')
+      end
+    end
   end
 
   describe '#initialize' do


### PR DESCRIPTION
*Transferred from [elastic/elasticsearch-ruby#1083](https://github.com/elastic/elasticsearch-ruby/pull/1104), original PR by @nsiregar*

### Original Pull Request message

This PR will reorder match_phrase query based on the documentation https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query.html and add some new match_phrase query 

will resolve #14