### PR TITLE
Adding missing runtime_mappings word to the search

### DIFF
--- a/lib/elasticsearch/dsl/search/options.rb
+++ b/lib/elasticsearch/dsl/search/options.rb
@@ -35,7 +35,8 @@ module Elasticsearch
           :indices_boost,
           :track_scores,
           :min_score,
-          :track_total_hits
+          :track_total_hits,
+          :runtime_mappings
         ]
 
         def initialize(*args, &block)

--- a/test/unit/search_options_test.rb
+++ b/test/unit/search_options_test.rb
@@ -57,6 +57,11 @@ module Elasticsearch
           assert_equal( { script_fields: ['foo'] }, subject.to_hash )
         end
 
+        should "encode runtime_mappings" do
+          subject.runtime_mappings ['foo']
+          assert_equal( { runtime_mappings: ['foo'] }, subject.to_hash )
+        end
+
         should "encode fielddata_fields" do
           subject.fielddata_fields ['foo']
           assert_equal( { fielddata_fields: ['foo'] }, subject.to_hash )


### PR DESCRIPTION
Adding runtime_mappings word to the search block 
[runtime_mappings Elasticsearch Reference](https://www.elastic.co/guide/en/elasticsearch/reference/current/runtime-search-request.html) 