### PR TITLE
add missing value attribute for aggregation

### DIFF
--- a/lib/elasticsearch/dsl/search.rb
+++ b/lib/elasticsearch/dsl/search.rb
@@ -224,6 +224,15 @@ module Elasticsearch
           end
         end; alias_method :size=, :size
 
+        def missing(value=nil)
+          if value
+            @missing = value
+            self
+          else
+            @missing
+          end
+        end; alias_method :missing=, :missing
+
         # DSL method for building the `from` part of a search definition
         #
         # @return [self]

--- a/lib/elasticsearch/dsl/search/aggregations/terms.rb
+++ b/lib/elasticsearch/dsl/search/aggregations/terms.rb
@@ -45,6 +45,7 @@ module Elasticsearch
 
           option_method :field
           option_method :size
+          option_method :missing
           option_method :shard_size
           option_method :order
           option_method :min_doc_count

--- a/lib/elasticsearch/dsl/search/base_compound_filter_component.rb
+++ b/lib/elasticsearch/dsl/search/base_compound_filter_component.rb
@@ -85,6 +85,10 @@ module Elasticsearch
             @value.size
           end
 
+          def missing
+            @value.size
+          end
+
           def <<(value)
             @value << value
           end

--- a/spec/elasticsearch/dsl/search/aggregations/terms_spec.rb
+++ b/spec/elasticsearch/dsl/search/aggregations/terms_spec.rb
@@ -58,6 +58,17 @@ describe Elasticsearch::DSL::Search::Aggregations::Terms do
       end
     end
 
+    describe '#missing' do
+
+      before do
+        search.missing('bar')
+      end
+
+      it 'applies the option' do
+        expect(search.to_hash[:terms][:foo][:missing]).to eq('bar')
+      end
+    end
+
     describe '#shard_size' do
 
       before do


### PR DESCRIPTION
elastic search allows to specify a default value for the records with null value.