### PR TITLE
Add support for terminate_after parameter

### DIFF
--- a/lib/elasticsearch/dsl/search/options.rb
+++ b/lib/elasticsearch/dsl/search/options.rb
@@ -35,7 +35,8 @@ module Elasticsearch
           :indices_boost,
           :track_scores,
           :min_score,
-          :track_total_hits
+          :track_total_hits,
+          :terminate_after
         ]
 
         def initialize(*args, &block)

--- a/test/unit/search_options_test.rb
+++ b/test/unit/search_options_test.rb
@@ -99,6 +99,11 @@ module Elasticsearch
           subject.min_score 0.5
           assert_equal( { min_score: 0.5 }, subject.to_hash )
         end
+
+        should "encode terminate_after" do
+          subject.terminate_after 10
+          assert_equal( { terminate_after: 10 }, subject.to_hash )
+        end
       end
     end
   end


### PR DESCRIPTION
Elasticsearch offers a `terminate_after` parameter:
> (Optional, integer) Maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting.

[[src](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html#search-source-param)]

This pull request adds support for this option in `Elasticsearch::DSL::Search::Options::DSL_METHODS`.